### PR TITLE
Fix: Avoid Overriding PyTorch's train Method in VAE Class

### DIFF
--- a/VAE/VAE_model.py
+++ b/VAE/VAE_model.py
@@ -309,7 +309,7 @@ class VAE(torch.nn.Module):
         return self.hparams
 
 
-    def train(self, genes):
+    def train_step(self, genes):
         """
         Train VAE.
         """

--- a/VAE/VAE_train.py
+++ b/VAE/VAE_train.py
@@ -82,7 +82,7 @@ def train_vae(args, return_model=False):
 
         genes, _ = next(datasets)
 
-        minibatch_training_stats = autoencoder.train(genes)
+        minibatch_training_stats = autoencoder.train_step(genes)
 
         if step % 1000 == 0:
             for key, val in minibatch_training_stats.items():


### PR DESCRIPTION

The `VAE` class originally had a custom `train` method, which unintentionally overrode PyTorch's built-in `train` method from `torch.nn.Module`. This caused an issue when calling:

```python
vae.train(False)  # Expected to switch to evaluation mode, but instead caused an error
```

Since `vae.train(False)` was invoking the custom `train` method instead of PyTorch's `train(False)`, `self.device` was incorrectly set to `False`, leading to the following error:

```
AttributeError: 'bool' object has no attribute 'to'
```

## **Solution**
### **1. Renaming `train` to `train_step`**
To prevent conflicts with PyTorch's `train` method, I renamed the custom `train` method to `train_step`. This ensures that calling `vae.train(False)` correctly switches to evaluation mode while still allowing training through the new method.

### **2. Updating `VAE_train.py`**
I also updated the reference in `VAE_train.py` :
```python
minibatch_training_stats = autoencoder.train_step(genes)
```


## **Correct Usage**
```python
vae.train(False)  # Correctly switches PyTorch to evaluation mode
vae.train_step(genes)  # Calls the intended training method
```